### PR TITLE
Add Modern Audio toggle in GUI settings

### DIFF
--- a/opencore_legacy_patcher/constants.py
+++ b/opencore_legacy_patcher/constants.py
@@ -237,6 +237,7 @@ class Constants:
         self.disable_mediaanalysisd: bool = False  # Set mediaanalysisd to spawn
         self.force_quad_thread:      bool = False #  Force quad thread mode (cpus=4)
         self.set_alc_usage:          bool = True  #  Set AppleALC usage
+        self.allow_modern_audio:     bool = True  #  Set Modern Audio support
         self.allow_3rd_party_drives: bool = True  #  Allow ThridPartyDrives quirk
         self.allow_nvme_fixing:      bool = True  #  Allow NVMe Kernel Space Patches
         self.apfs_trim_timeout:      bool = True  #  Set APFS Trim timeout

--- a/opencore_legacy_patcher/support/defaults.py
+++ b/opencore_legacy_patcher/support/defaults.py
@@ -54,6 +54,7 @@ class GenerateDefaults:
         self.constants.disallow_cpufriend = False
         self.constants.disable_mediaanalysisd = False
         self.constants.set_alc_usage = True
+        self.constants.allow_modern_audio = True
         self.constants.nvram_write = True
         self.constants.allow_nvme_fixing = True
         self.constants.allow_3rd_party_drives = True

--- a/opencore_legacy_patcher/sys_patch/patchsets/hardware/misc/modern_audio.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/hardware/misc/modern_audio.py
@@ -26,8 +26,10 @@ class ModernAudio(BaseHardware):
 
     def present(self) -> bool:
         """
-        AppleHDA was outright removed in macOS 26, so this patch set is always present if OS requires it
+        AppleHDA was outright removed in macOS Tahoe, so this patch set is always present if OS requires it
         """
+        if self._constants.allow_modern_audio is False:
+            return False
         return True
 
 

--- a/opencore_legacy_patcher/wx_gui/gui_settings.py
+++ b/opencore_legacy_patcher/wx_gui/gui_settings.py
@@ -712,6 +712,18 @@ class SettingsFrame(wx.Frame):
                     "override_function": self._update_global_settings,
                     "condition": not bool(self.constants.computer.real_model not in ["MacBookPro8,2", "MacBookPro8,3"])
                 },
+                "Modern Audio": {
+                    "type": "checkbox",
+                    "value": self.constants.allow_modern_audio,
+                    "variable": "allow_modern_audio",
+                    "description": [
+                        "Enable Modern Audio patches for",
+                        "macOS Tahoe and newer.",
+                        "Only disable if you lack a KDK",
+                        "for the current OS version.",
+                    ],
+                    "condition": self.constants.detected_os >= os_data.os_data.tahoe
+                },
                 "wrap_around 1": {
                     "type": "wrap_around",
                 },


### PR DESCRIPTION
This change adds a new toggle in the OpenCore Legacy Patcher settings under the "Root Patching" tab. This toggle allows users to manually disable the "Modern Audio" root patch, which is required for audio support on macOS Tahoe (macOS 16) but depends on the availability of a Kernel Debug Kit (KDK). By providing this toggle, users can still apply other root patches even if the KDK for the audio patch is missing.

---
*PR created automatically by Jules for task [14180453938666792298](https://jules.google.com/task/14180453938666792298) started by @YBronst*