### PR TITLE
Remove "Official Phone Support" button from Help menu

### DIFF
--- a/opencore_legacy_patcher/wx_gui/gui_help.py
+++ b/opencore_legacy_patcher/wx_gui/gui_help.py
@@ -33,7 +33,6 @@ class HelpFrame(wx.Frame):
             - Text:  Following resources are available:
             - Button: Official Guide
             - Button: Community Discord Server
-            - Button: Official Phone Support
             - Button: Return to Main Menu
         """
 
@@ -49,7 +48,6 @@ class HelpFrame(wx.Frame):
 
         buttons = {
             "Official Guide":           self.constants.guide_link,
-            "Official Phone Support":   "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             "Community Discord Server": self.constants.discord_link,
         }
 


### PR DESCRIPTION
Removed the non-functional "Official Phone Support" button from the Help menu in the wxPython GUI. This button previously linked to a Rickroll video and was no longer desired. Both the implementation and the class docstring have been updated to reflect this change.

---
*PR created automatically by Jules for task [5917521018838256704](https://jules.google.com/task/5917521018838256704) started by @YBronst*