### PR TITLE
Move Modern Audio switch to the right of TeraScale 2 Acceleration

### DIFF
--- a/opencore_legacy_patcher/wx_gui/gui_settings.py
+++ b/opencore_legacy_patcher/wx_gui/gui_settings.py
@@ -712,6 +712,9 @@ class SettingsFrame(wx.Frame):
                     "override_function": self._update_global_settings,
                     "condition": not bool(self.constants.computer.real_model not in ["MacBookPro8,2", "MacBookPro8,3"])
                 },
+                "wrap_around 1": {
+                    "type": "wrap_around",
+                },
                 "Modern Audio": {
                     "type": "checkbox",
                     "value": self.constants.allow_modern_audio,
@@ -723,9 +726,6 @@ class SettingsFrame(wx.Frame):
                         "for the current OS version.",
                     ],
                     "condition": self.constants.detected_os >= os_data.os_data.tahoe
-                },
-                "wrap_around 1": {
-                    "type": "wrap_around",
                 },
                 "Non-Metal Configuration": {
                     "type": "title",


### PR DESCRIPTION
This change repositions the "Modern Audio" toggle to the right of the "TeraScale 2 Acceleration" toggle in the Root Patching settings. By moving the "wrap_around 1" marker between these two items in the settings dictionary, they are now displayed in two columns instead of one. This was done to optimize vertical space in the settings menu.

---
*PR created automatically by Jules for task [18021098537133271843](https://jules.google.com/task/18021098537133271843) started by @YBronst*