### PR TITLE
Implement dynamic resource fallback for macOS Tahoe

### DIFF
--- a/opencore_legacy_patcher/sys_patch/sys_patch.py
+++ b/opencore_legacy_patcher/sys_patch/sys_patch.py
@@ -510,11 +510,28 @@ class PatchSysVolume:
                         except TypeError:
                             pass
 
-                        source_file = required_patches[patch][method_type][install_patch_directory][install_file] + install_patch_directory + "/" + install_file
+                        source_dir = required_patches[patch][method_type][install_patch_directory][install_file]
+                        source_file = source_dir + install_patch_directory + "/" + install_file
 
                         # Check whether to source from root
-                        if not required_patches[patch][method_type][install_patch_directory][install_file].startswith("/"):
+                        if not source_dir.startswith("/"):
                             source_file = source_files_path + "/" + source_file
+
+                        if not Path(source_file).exists():
+                            # Fallback logic for Tahoe (XNU 25)
+                            # If resource for Tahoe is missing, fallback to Sequoia (XNU 24)
+                            if self.constants.detected_os == os_data.os_data.tahoe:
+                                if source_dir.endswith("-25"):
+                                    fallback_dir = source_dir[:-2] + "24"
+                                    fallback_file = fallback_dir + install_patch_directory + "/" + install_file
+                                    if not fallback_dir.startswith("/"):
+                                        fallback_file = source_files_path + "/" + fallback_file
+
+                                    if Path(fallback_file).exists():
+                                        logging.info(f"- Resource {source_dir} missing, falling back to {fallback_dir}")
+                                        required_patches[patch][method_type][install_patch_directory][install_file] = fallback_dir
+                                        source_file = fallback_file
+
                         if not Path(source_file).exists():
                             raise Exception(f"Failed to find {source_file}")
 


### PR DESCRIPTION
This change introduces a dynamic fallback mechanism in the root patching engine. When the patcher is running on macOS Tahoe (XNU 25) and encounters a missing resource directory that ends with the '-25' suffix, it will automatically attempt to locate and use the equivalent resource with the '-24' suffix (Sequoia). This ensures that systems can still receive necessary patches even before Tahoe-specific resources are fully integrated into the PatcherSupportPkg. The logic is applied during the preflight check phase and updates the patchset metadata accordingly.

---
*PR created automatically by Jules for task [17362421420220864983](https://jules.google.com/task/17362421420220864983) started by @YBronst*