### PR TITLE
Fix AirDrop on Sequoia and Tahoe for Modern Wireless chipsets

### DIFF
--- a/opencore_legacy_patcher/sys_patch/patchsets/hardware/networking/modern_wireless.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/hardware/networking/modern_wireless.py
@@ -76,9 +76,6 @@ class ModernWireless(BaseHardware):
         """
         Extended patches for Modern Wireless
         """
-        if self._xnu_major > os_data.sonoma:
-            return {}
-
         return {
             "Modern Wireless Extended": {
                 PatchType.OVERWRITE_SYSTEM_VOLUME: {
@@ -88,7 +85,7 @@ class ModernWireless(BaseHardware):
                 },
                 PatchType.MERGE_SYSTEM_VOLUME: {
                     "/System/Library/Frameworks": {
-                        **({ "CoreWLAN.framework": f"13.7.2-{self._xnu_major}" } if self._xnu_major == os_data.sonoma else {}),
+                        **({ "CoreWLAN.framework": f"13.7.2-{self._xnu_major}" } if self._xnu_major >= os_data.sonoma else {}),
                     },
                     "/System/Library/PrivateFrameworks": {
                         "CoreWiFi.framework":       f"13.7.2-{self._xnu_major}",


### PR DESCRIPTION
Fixed an issue where AirDrop was non-functional on macOS Sequoia and Tahoe for Macs with Modern Wireless (Broadcom BCM4360) chipsets. The fix involved enabling necessary extended patches (airportd, CoreWiFi, and CoreWLAN) that were previously restricted to Sonoma and older versions.

---
*PR created automatically by Jules for task [13682015942379758020](https://jules.google.com/task/13682015942379758020) started by @YBronst*