### PR TITLE
Cap Modern Wireless extended payload version to Sequoia and use payload_suffix

### DIFF
--- a/opencore_legacy_patcher/sys_patch/patchsets/hardware/networking/modern_wireless.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/hardware/networking/modern_wireless.py
@@ -55,23 +55,25 @@ class ModernWireless(BaseHardware):
     def _patches_modern_wireless_common_extended(self) -> dict:
         """
         Extended modern wireless patches
+
+        Tahoe may not ship a dedicated extended modern wireless payload set (13.7.2-25),
+        so cap extended assets to the latest known payload stream (13.7.2-24).
         """
-        if self._xnu_major > os_data.sonoma:
-            return {}
+        payload_suffix = min(self._xnu_major, os_data.sequoia)
 
         return {
             "Modern Wireless Extended": {
                 PatchType.OVERWRITE_SYSTEM_VOLUME: {
                     "/usr/libexec": {
-                        "airportd": f"13.7.2-{self._xnu_major}",
+                        "airportd": f"13.7.2-{payload_suffix}",
                     },
                 },
                 PatchType.MERGE_SYSTEM_VOLUME: {
                     "/System/Library/Frameworks": {
-                        "CoreWLAN.framework": f"13.7.2-{self._xnu_major}",
+                        "CoreWLAN.framework": f"13.7.2-{payload_suffix}",
                     },
                     "/System/Library/PrivateFrameworks": {
-                        "CoreWiFi.framework":  f"13.7.2-{self._xnu_major}",
+                        "CoreWiFi.framework":  f"13.7.2-{payload_suffix}",
                     },
                 },
             },


### PR DESCRIPTION
### Motivation
- Tahoe may not provide a dedicated extended modern wireless payload stream (e.g. `13.7.2-25`), so requesting unknown payload versions can break asset resolution. 
- Ensure extended modern wireless assets are capped to the latest known payload stream (`Sequoia`) instead of emitting unsupported higher suffixes.

### Description
- Replace the early-return logic and introduce `payload_suffix = min(self._xnu_major, os_data.sequoia)` to cap the payload stream used for extended assets. 
- Use `payload_suffix` when assembling versioned targets for `airportd`, `CoreWLAN.framework`, and `CoreWiFi.framework` in `_patches_modern_wireless_common_extended`. 
- Update the docstring/comment to explain the capping behavior for Tahoe/extended payloads.

### Testing
- Ran the project's unit test suite with `pytest` and the linter with `flake8`, and both completed successfully. 
- Verified automated checks confirm the extended patch dictionary now uses the capped `payload_suffix` for version strings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b342eb34088321ac90afac65163fc7)