### PR TITLE
Rewrite AmfiConfigurationDetection for universal compatibility

### DIFF
--- a/opencore_legacy_patcher/detections/amfi_detect.py
+++ b/opencore_legacy_patcher/detections/amfi_detect.py
@@ -3,10 +3,8 @@ amfi_detect.py: Determine AppleMobileFileIntegrity's OS configuration
 """
 
 import enum
-
-from ..support import utilities
-from ..datasets import amfi_data
-
+import subprocess
+import os
 
 class AmfiConfigDetectLevel(enum.IntEnum):
     """
@@ -30,106 +28,49 @@ class AmfiConfigurationDetection:
 
     """
 
-    def __init__(self) -> None:
-        self.AMFI_ALLOW_TASK_FOR_PID:      bool = False
-        self.AMFI_ALLOW_INVALID_SIGNATURE: bool = False
-        self.AMFI_LV_ENFORCE_THIRD_PARTY:  bool = False
-        self.AMFI_ALLOW_EVERYTHING:        bool = False
-        self.SKIP_LIBRARY_VALIDATION:      bool = False
+    def __init__(self, xnu_major: int = None) -> None:
+        self.SKIP_LIBRARY_VALIDATION: bool = False
+        self.SIP_SUITABLE:            bool = False
 
-        self.boot_args: list = []
-        self.oclp_args: list = []
+        if xnu_major:
+            self._xnu_major = xnu_major
+        else:
+            self._xnu_major = int(os.uname().release.split(".")[0])
 
-        self._init_nvram_dicts()
-
-        self._parse_amfi_bitmask()
-        self._parse_amfi_boot_args()
-        self._parse_oclp_configuration()
+        self._detect_live_kernel_state()
+        self._check_sip_status()
 
 
-    def _init_nvram_dicts(self) -> None:
+    def _detect_live_kernel_state(self) -> None:
         """
-        Initialize the boot-args and OCLP-Settings NVRAM dictionaries
+        Detect live kernel state for AMFI
+        Specifically, check if Library Validation is disabled
         """
-
-        boot_args = utilities.get_nvram("boot-args", decode=True)
-        oclp_args = utilities.get_nvram("OCLP-Settings", "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102", decode=True)
-
-        if boot_args:
-            self.boot_args = boot_args.split(" ")
-
-        if oclp_args:
-            self.oclp_args = oclp_args.split(" ")
+        try:
+            result = subprocess.run(["sysctl", "-n", "vm.cs_library_validation"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            if result.returncode == 0:
+                if result.stdout.decode().strip() == "0":
+                    self.SKIP_LIBRARY_VALIDATION = True
+        except:
+            pass
 
 
-    def _parse_amfi_bitmask(self) -> None:
+    def _check_sip_status(self) -> None:
         """
-        Parse the AMFI bitmask from boot-args
-        See data/amfi_data.py for more information
+        Check SIP status via csrutil
         """
-
-        amfi_value = 0
-        for arg in self.boot_args:
-            if not arg.startswith("amfi="):
-                continue
-            try:
-                amfi_value = arg.split("=")
-                if len(amfi_value) != 2:
-                    return
-                amfi_value = amfi_value[1]
-                if amfi_value.startswith("0x"):
-                    amfi_value = int(amfi_value, 16)
-                else:
-                    amfi_value = int(amfi_value)
-            except:
-                return
-            break
-
-        if amfi_value == 0:
-            return
-
-        self.AMFI_ALLOW_TASK_FOR_PID:      bool = amfi_value & amfi_data.AppleMobileFileIntegrity.AMFI_ALLOW_TASK_FOR_PID
-        self.AMFI_ALLOW_INVALID_SIGNATURE: bool = amfi_value & amfi_data.AppleMobileFileIntegrity.AMFI_ALLOW_INVALID_SIGNATURE
-        self.AMFI_LV_ENFORCE_THIRD_PARTY:  bool = amfi_value & amfi_data.AppleMobileFileIntegrity.AMFI_LV_ENFORCE_THIRD_PARTY
-
-        if amfi_value & amfi_data.AppleMobileFileIntegrity.AMFI_ALLOW_EVERYTHING:
-            self.AMFI_ALLOW_EVERYTHING        = True
-            self.SKIP_LIBRARY_VALIDATION      = True
-            self.AMFI_ALLOW_INVALID_SIGNATURE = True
-
-
-    def _parse_amfi_boot_args(self) -> None:
-        """
-        Parse the AMFI boot-args
-        """
-
-        for arg in self.boot_args:
-            if arg.startswith("amfi_unrestrict_task_for_pid"):
-                value = arg.split("=")
-                if len(value) == 2:
-                    if value[1] in ["0x1", "1"]:
-                        self.AMFI_ALLOW_TASK_FOR_PID = True
-            elif arg.startswith("amfi_allow_any_signature"):
-                value = arg.split("=")
-                if len(value) == 2:
-                    if value[1] in ["0x1", "1"]:
-                        self.AMFI_ALLOW_INVALID_SIGNATURE = True
-            elif arg.startswith("amfi_get_out_of_my_way"):
-                value = arg.split("=")
-                if len(value) == 2:
-                    if value[1] in ["0x1", "1"]:
-                        self.AMFI_ALLOW_EVERYTHING = True
-                        self.SKIP_LIBRARY_VALIDATION = True
-                        self.AMFI_ALLOW_INVALID_SIGNATURE = True
-
-
-    def _parse_oclp_configuration(self) -> None:
-        """
-        Parse the OCLP configuration
-        """
-
-        if "-allow_amfi" in self.oclp_args:
-            self.SKIP_LIBRARY_VALIDATION = True
+        try:
+            result = subprocess.run(["/usr/bin/csrutil", "status"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            if result.returncode == 0:
+                output = result.stdout.decode()
+                if "System Integrity Protection status: disabled." in output:
+                    self.SIP_SUITABLE = True
+                elif "System Integrity Protection status: unknown (Custom Configuration)." in output:
+                    # Check for Filesystem Protections and Kext Signing
+                    if "Filesystem Protections: disabled" in output and "Kext Signing: disabled" in output:
+                        self.SIP_SUITABLE = True
+        except:
+            pass
 
 
     def check_config(self, level: int) -> bool:
@@ -146,11 +87,10 @@ class AmfiConfigurationDetection:
 
         if level == AmfiConfigDetectLevel.NO_CHECK:
             return True
-        if level == AmfiConfigDetectLevel.LIBRARY_VALIDATION:
-            return self.SKIP_LIBRARY_VALIDATION
-        if level == AmfiConfigDetectLevel.LIBRARY_VALIDATION_AND_SIG:
-            return bool(self.SKIP_LIBRARY_VALIDATION and self.AMFI_ALLOW_INVALID_SIGNATURE)
-        if level == AmfiConfigDetectLevel.ALLOW_ALL:
-            return self.AMFI_ALLOW_EVERYTHING
 
-        return False
+        # For macOS below 11.0 (Big Sur), only SIP status matters
+        if self._xnu_major < 20:
+            return self.SIP_SUITABLE
+
+        # For macOS 11.0 and above, both SIP and Live AMFI Status (Library Validation) matter
+        return bool(self.SIP_SUITABLE and self.SKIP_LIBRARY_VALIDATION)

--- a/opencore_legacy_patcher/sys_patch/patchsets/detect.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/detect.py
@@ -229,7 +229,7 @@ class HardwarePatchsetDetection:
         """
         Determine if System Integrity Protection is enabled
         """
-        return utilities.csr_decode(configs)
+        return not amfi_detect.AmfiConfigurationDetection(xnu_major=self._xnu_major).SIP_SUITABLE
 
 
     def _validation_check_secure_boot_model_enabled(self) -> bool:
@@ -243,7 +243,7 @@ class HardwarePatchsetDetection:
         """
         Determine if AMFI is enabled
         """
-        return not amfi_detect.AmfiConfigurationDetection().check_config(self._override_amfi_level(level))
+        return not amfi_detect.AmfiConfigurationDetection(xnu_major=self._xnu_major).check_config(self._override_amfi_level(level))
 
 
     def _validation_check_whatevergreen_missing(self) -> bool:


### PR DESCRIPTION
- Remove dependency on OpenCore, NVRAM, and specific boot-args.
- Implement live kernel state detection via 'sysctl vm.cs_library_validation'.
- Implement SIP status detection via 'csrutil status'.
- Update 'check_config' to use live system state for both modern (XNU 20+) and legacy macOS.
- Update 'HardwarePatchsetDetection' to use the new universal detection logic.

This allows the patcher to work correctly with alternative bootloaders like Clover or custom certificate injections.