### PR TITLE
Fix update mechanism after rebranding to OCLP-Plus

### DIFF
--- a/oclp_plus/constants.py
+++ b/oclp_plus/constants.py
@@ -23,9 +23,9 @@ class Constants:
         self.discord_link:                    str = "https://discord.gg/rqdPgH8xSN"
         self.guide_link:                      str = "https://dortania.github.io/OpenCore-Legacy-Patcher/"
         self.kdk_support_pkg_link:            str = "https://github.com/dortania/KdkSupportPkg/releases"
-        self.repo_link:                       str = "https://github.com/YBronst/OpenCore-Legacy-Patcher"
+        self.repo_link:                       str = "https://github.com/YBronst/OCLP-Plus"
         self.installer_pkg_url:               str = f"{self.repo_link}/releases/download/{self.patcher_version}/AutoPkg-Assets.pkg"
-        self.installer_pkg_url_nightly:       str = "http://nightly.link/YBronst/OpenCore-Legacy-Patcher/workflows/build-app-wxpython/main/AutoPkg-Assets.pkg.zip"
+        self.installer_pkg_url_nightly:       str = "http://nightly.link/YBronst/OCLP-Plus/workflows/build-app-wxpython/main/AutoPkg-Assets.pkg.zip"
 
         # OpenCore Versioning
         # https://github.com/acidanthera/OpenCorePkg

--- a/oclp_plus/support/updates.py
+++ b/oclp_plus/support/updates.py
@@ -15,7 +15,7 @@ from . import network_handler
 from .. import constants
 
 
-REPO_LATEST_RELEASE_URL: str = "https://api.github.com/repos/YBronst/OpenCore-Legacy-Patcher/releases/latest"
+REPO_LATEST_RELEASE_URL: str = "https://api.github.com/repos/YBronst/OCLP-Plus/releases/latest"
 
 
 class CheckBinaryUpdates:
@@ -116,12 +116,12 @@ class CheckBinaryUpdates:
 
         for asset in data_set["assets"]:
             logging.info(f"Found asset: {asset['name']}")
-            if asset["name"] == "OpenCore-Patcher.pkg":
+            if asset["name"] == "OCLP-Plus.pkg":
                 self.latest_details = {
                     "Name": asset["name"],
                     "Version": latest_remote_version,
                     "Link": asset["browser_download_url"],
-                    "Github Link": f"https://github.com/YBronst/OpenCore-Legacy-Patcher/releases/{latest_remote_version}",
+                    "Github Link": f"https://github.com/YBronst/OCLP-Plus/releases/{latest_remote_version}",
                 }
                 return self.latest_details
 

--- a/oclp_plus/wx_gui/gui_settings.py
+++ b/oclp_plus/wx_gui/gui_settings.py
@@ -1351,7 +1351,7 @@ Hardware Information:
         branches = ["main"]
         if self.constants.commit_info[0] not in ["Running from source", "Built from source"]:
             branches = [self.constants.commit_info[0].split("/")[-1]]
-        result = network_handler.NetworkUtilities().get("https://api.github.com/repos/dortania/OpenCore-Legacy-Patcher/branches")
+        result = network_handler.NetworkUtilities().get("https://api.github.com/repos/YBronst/OCLP-Plus/branches")
         if result is not None:
             result = result.json()
             for branch in result:
@@ -1373,7 +1373,7 @@ Hardware Information:
             title=self.title,
             global_constants=self.constants,
             screen_location=self.parent.GetPosition(),
-            url=f"https://nightly.link/dortania/OpenCore-Legacy-Patcher/workflows/build-app-wxpython/{branch}/OpenCore-Patcher.pkg.zip",
+            url=f"https://nightly.link/YBronst/OCLP-Plus/workflows/build-app-wxpython/{branch}/OCLP-Plus.pkg.zip",
             version_label="(Nightly)"
         )
 

--- a/oclp_plus/wx_gui/gui_update.py
+++ b/oclp_plus/wx_gui/gui_update.py
@@ -42,7 +42,7 @@ class UpdateFrame(wx.Frame):
 
         self.title: str = title
         self.constants: constants.Constants = global_constants
-        self.pkg_download_path = self.constants.payload_path / "OpenCore-Patcher.pkg"
+        self.pkg_download_path = self.constants.payload_path / "OCLP-Plus.pkg"
         self.screen_location: wx.Point = screen_location
         if parent:
             self.parent.Centre()
@@ -97,7 +97,7 @@ class UpdateFrame(wx.Frame):
         download_obj = None
         def _fetch_update() -> None:
             nonlocal download_obj
-            file_name = "OpenCore-Patcher.pkg.zip" if url.endswith(".zip") else "OpenCore-Patcher.pkg"
+            file_name = "OCLP-Plus.pkg.zip" if url.endswith(".zip") else "OCLP-Plus.pkg"
             download_obj = network_handler.DownloadObject(url, self.constants.payload_path / file_name)
 
         thread = threading.Thread(target=_fetch_update)
@@ -109,7 +109,7 @@ class UpdateFrame(wx.Frame):
             title=self.title,
             global_constants=self.constants,
             download_obj=download_obj,
-            item_name=f"OpenCore Patcher {version_label}",
+            item_name=f"OCLP-Plus {version_label}",
             download_icon=str(self.constants.app_icon_path)
         )
 
@@ -199,7 +199,7 @@ class UpdateFrame(wx.Frame):
             subprocess.run(["/bin/rm", "-rf", str(self.pkg_download_path)])
 
         result = subprocess.run(
-            ["/usr/bin/ditto", "-xk", str(self.constants.payload_path / "OpenCore-Patcher.pkg.zip"), str(self.constants.payload_path)], capture_output=True
+            ["/usr/bin/ditto", "-xk", str(self.constants.payload_path / "OCLP-Plus.pkg.zip"), str(self.constants.payload_path)], capture_output=True
         )
         if result.returncode != 0:
             logging.error(f"Failed to extract update.")
@@ -230,7 +230,7 @@ class UpdateFrame(wx.Frame):
                 logging.error("Failed to install update, attempting to open PKG")
                 subprocess.run(["/usr/bin/open", str(self.pkg_download_path)])
 
-                wx.CallAfter(wx.MessageBox, f"Failed to install update. Please try installing the OpenCore-Patcher.pkg manually or download from GitHub", "Critical Error!", wx.OK | wx.ICON_ERROR)
+                wx.CallAfter(wx.MessageBox, f"Failed to install update. Please try installing the OCLP-Plus.pkg manually or download from GitHub", "Critical Error!", wx.OK | wx.ICON_ERROR)
             wx.CallAfter(sys.exit, 1)
 
 


### PR DESCRIPTION
- Update `repo_link` and nightly build URLs in `constants.py` to point to `YBronst/OCLP-Plus`.
- Update `REPO_LATEST_RELEASE_URL` and asset name check in `updates.py` to recognize `OCLP-Plus.pkg`.
- Replace all occurrences of `OpenCore-Patcher.pkg` with `OCLP-Plus.pkg` in `gui_update.py`.
- Update nightly build and branch fetching URLs in `gui_settings.py`.
- Respect constraints: do not touch `privileged_helper_tool` or `CHANGELOG.md`.