### PR TITLE
release: 3.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # OCLP-Plus changelog
+## 3.1.9
+
+- Re-enable legacy hardware patches (Intel, NVIDIA, AMD, legacy wireless, etc.)
+- Only include these patches when the system's XNU major version is less than 25 (Tahoe)
+- Ensure ModernWireless and ModernAudio remain enabled for all versions (including Tahoe and newer)
+- Maintain the original patch detection order
+
 ## 3.1.8
 
    * **Move JavaScriptCore patch for pre-AVX Macs** to RestrictEvents

--- a/oclp_plus/constants.py
+++ b/oclp_plus/constants.py
@@ -13,7 +13,7 @@ from .detections import device_probe
 class Constants:
     def __init__(self) -> None:
         # Patcher Versioning
-        self.patcher_version:                 str = "3.1.8"  # OCLP-Plus
+        self.patcher_version:                 str = "3.1.9"  # OCLP-Plus
         self.patcher_support_pkg_version:     str = "2.0.0"  # PatcherSupportPkg
         self.copyright_date:                  str = "Copyright © 2020-2026 Dortania and YBronst"
         self.patcher_name:                    str = "OCLP-Plus"


### PR DESCRIPTION
- Re-enable legacy hardware patches (Intel, NVIDIA, AMD, legacy wireless, etc.)
- Only include these patches when the system's XNU major version is less than 25 (Tahoe)
- Ensure ModernWireless and ModernAudio remain enabled for all versions (including Tahoe and newer)
- Maintain the original patch detection order
- Bump version to 3.1.9
- Update CHANGELOG.md