### PR TITLE
Main 18272373703905268835

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # OCLP-Plus changelog
+## 3.1.9
+
+- Re-enable legacy hardware patches (Intel, NVIDIA, AMD, legacy wireless, etc.)
+- Only include these patches when the system's XNU major version is less than 25 (Tahoe)
+- Ensure ModernWireless and ModernAudio remain enabled for all versions (including Tahoe and newer)
+- Maintain the original patch detection order
+
 ## 3.1.8
 
    * **Move JavaScriptCore patch for pre-AVX Macs** to RestrictEvents

--- a/oclp_plus/constants.py
+++ b/oclp_plus/constants.py
@@ -13,7 +13,7 @@ from .detections import device_probe
 class Constants:
     def __init__(self) -> None:
         # Patcher Versioning
-        self.patcher_version:                 str = "3.1.8"  # OCLP-Plus
+        self.patcher_version:                 str = "3.1.9"  # OCLP-Plus
         self.patcher_support_pkg_version:     str = "2.0.0"  # PatcherSupportPkg
         self.copyright_date:                  str = "Copyright © 2020-2026 Dortania and YBronst"
         self.patcher_name:                    str = "OCLP-Plus"

--- a/oclp_plus/sys_patch/patchsets/detect.py
+++ b/oclp_plus/sys_patch/patchsets/detect.py
@@ -108,38 +108,47 @@ class HardwarePatchsetDetection:
         self._os_version = os_version or self._constants.detected_os_version
         self._validation = validation
 
-        self._hardware_variants = [
-            #intel_iron_lake.IntelIronLake,
-            #intel_sandy_bridge.IntelSandyBridge,
-            #intel_ivy_bridge.IntelIvyBridge,
-            #intel_haswell.IntelHaswell,
-            #intel_broadwell.IntelBroadwell,
-            #intel_skylake.IntelSkylake,
+        self._hardware_variants = []
 
-            #nvidia_tesla.NvidiaTesla,
-            #nvidia_kepler.NvidiaKepler,
-            #nvidia_webdriver.NvidiaWebDriver,
+        if self._xnu_major < os_data.tahoe.value:
+            self._hardware_variants += [
+                intel_iron_lake.IntelIronLake,
+                intel_sandy_bridge.IntelSandyBridge,
+                intel_ivy_bridge.IntelIvyBridge,
+                intel_haswell.IntelHaswell,
+                intel_broadwell.IntelBroadwell,
+                intel_skylake.IntelSkylake,
 
-            #amd_terascale_1.AMDTeraScale1,
-            #amd_terascale_2.AMDTeraScale2,
-            #amd_legacy_gcn.AMDLegacyGCN,
-            #amd_polaris.AMDPolaris,
-            #amd_vega.AMDVega,
+                nvidia_tesla.NvidiaTesla,
+                nvidia_kepler.NvidiaKepler,
+                nvidia_webdriver.NvidiaWebDriver,
 
-            #legacy_wireless.LegacyWireless,
-            modern_wireless.ModernWireless,
+                amd_terascale_1.AMDTeraScale1,
+                amd_terascale_2.AMDTeraScale2,
+                amd_legacy_gcn.AMDLegacyGCN,
+                amd_polaris.AMDPolaris,
+                amd_vega.AMDVega,
 
-            #legacy_audio.LegacyAudio,
-            modern_audio.ModernAudio,
+                legacy_wireless.LegacyWireless,
+            ]
 
-            #display_backlight.DisplayBacklight,
-            #gmux.GraphicsMultiplexer,
-            #keyboard_backlight.KeyboardBacklight,
-            #pcie_webcam.PCIeFaceTimeCamera,
-            #t1_security.T1SecurityChip,
-            #usb11.USB11Controller,
-            #cpu_missing_avx.CPUMissingAVX,
-        ]
+        self._hardware_variants.append(modern_wireless.ModernWireless)
+
+        if self._xnu_major < os_data.tahoe.value:
+            self._hardware_variants.append(legacy_audio.LegacyAudio)
+
+        self._hardware_variants.append(modern_audio.ModernAudio)
+
+        if self._xnu_major < os_data.tahoe.value:
+            self._hardware_variants += [
+                display_backlight.DisplayBacklight,
+                gmux.GraphicsMultiplexer,
+                keyboard_backlight.KeyboardBacklight,
+                pcie_webcam.PCIeFaceTimeCamera,
+                t1_security.T1SecurityChip,
+                usb11.USB11Controller,
+                cpu_missing_avx.CPUMissingAVX,
+            ]
 
         self.device_properties = None
         self.patches           = None

--- a/oclp_plus/sys_patch/patchsets/hardware/networking/legacy_wireless.py
+++ b/oclp_plus/sys_patch/patchsets/hardware/networking/legacy_wireless.py
@@ -87,14 +87,12 @@ class LegacyWireless(BaseHardware):
         """
         Base patches for Legacy Wireless
         """
-        daemons = {}
-        if self._xnu_major < 25:
-            daemons["airportd"] = "11.7.10" if self._affected_by_cve_2024_23227 is False else "11.7.10-Sandbox"
-
         return {
             "Legacy Wireless": {
                 PatchType.OVERWRITE_SYSTEM_VOLUME: {
-                    "/usr/libexec": daemons,
+                    "/usr/libexec": {
+                        "airportd": "11.7.10" if self._affected_by_cve_2024_23227 is False else "11.7.10-Sandbox",
+                    },
                     "/System/Library/CoreServices": {
                         "WiFiAgent.app": "11.7.10",
                     },
@@ -116,17 +114,13 @@ class LegacyWireless(BaseHardware):
         if self._xnu_major < os_data.ventura:
             return {}
 
-        daemons = {
-            "wps":      "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}",
-            "wifip2pd": "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}",
-        }
-        if self._xnu_major < 25:
-            daemons["airportd"] = "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}"
-
         return {
             "Legacy Wireless Extended": {
                 PatchType.OVERWRITE_SYSTEM_VOLUME: {
-                    "/usr/libexec": daemons,
+                    "/usr/libexec": {
+                        "wps":      "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}",
+                        "wifip2pd": "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}",
+                    },
                 },
                 PatchType.MERGE_SYSTEM_VOLUME: {
                     "/System/Library/Frameworks": {

--- a/oclp_plus/sys_patch/patchsets/hardware/networking/legacy_wireless.py
+++ b/oclp_plus/sys_patch/patchsets/hardware/networking/legacy_wireless.py
@@ -87,12 +87,14 @@ class LegacyWireless(BaseHardware):
         """
         Base patches for Legacy Wireless
         """
+        daemons = {}
+        if self._xnu_major < 25:
+            daemons["airportd"] = "11.7.10" if self._affected_by_cve_2024_23227 is False else "11.7.10-Sandbox"
+
         return {
             "Legacy Wireless": {
                 PatchType.OVERWRITE_SYSTEM_VOLUME: {
-                    "/usr/libexec": {
-                        "airportd": "11.7.10" if self._affected_by_cve_2024_23227 is False else "11.7.10-Sandbox",
-                    },
+                    "/usr/libexec": daemons,
                     "/System/Library/CoreServices": {
                         "WiFiAgent.app": "11.7.10",
                     },
@@ -114,13 +116,17 @@ class LegacyWireless(BaseHardware):
         if self._xnu_major < os_data.ventura:
             return {}
 
+        daemons = {
+            "wps":      "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}",
+            "wifip2pd": "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}",
+        }
+        if self._xnu_major < 25:
+            daemons["airportd"] = "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}"
+
         return {
             "Legacy Wireless Extended": {
                 PatchType.OVERWRITE_SYSTEM_VOLUME: {
-                    "/usr/libexec": {
-                        "wps":      "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}",
-                        "wifip2pd": "12.7.2" if self._xnu_major < os_data.sequoia else f"12.7.2-{self._xnu_major}",
-                    },
+                    "/usr/libexec": daemons,
                 },
                 PatchType.MERGE_SYSTEM_VOLUME: {
                     "/System/Library/Frameworks": {

--- a/oclp_plus/sys_patch/patchsets/hardware/networking/modern_wireless.py
+++ b/oclp_plus/sys_patch/patchsets/hardware/networking/modern_wireless.py
@@ -56,12 +56,14 @@ class ModernWireless(BaseHardware):
         """
         Base patches for Modern Wireless
         """
+        daemons = {"wifip2pd": f"13.7.2-{self._xnu_major}"}
+        if self._xnu_major < 25:
+            daemons["airportd"] = f"13.7.2-{self._xnu_major}"
+
         return {
             "Modern Wireless": {
                 PatchType.OVERWRITE_SYSTEM_VOLUME: {
-                    "/usr/libexec": {
-                        "wifip2pd": f"13.7.2-{self._xnu_major}",
-                    },
+                    "/usr/libexec": daemons,
                 },
                 PatchType.MERGE_SYSTEM_VOLUME: {
                     "/System/Library/PrivateFrameworks": {
@@ -76,22 +78,17 @@ class ModernWireless(BaseHardware):
         """
         Extended patches for Modern Wireless
         """
-        if self._xnu_major > os_data.sonoma:
+        if self.native_os() is True:
             return {}
 
         return {
             "Modern Wireless Extended": {
-                PatchType.OVERWRITE_SYSTEM_VOLUME: {
-                    "/usr/libexec": {
-                        "wifip2pd": f"13.7.2-{self._xnu_major}",
-                    },
-                },
                 PatchType.MERGE_SYSTEM_VOLUME: {
                     "/System/Library/Frameworks": {
-                        **({ "CoreWLAN.framework": f"13.7.2-{self._xnu_major}" } if self._xnu_major == os_data.sonoma else {}),
+                        "CoreWLAN.framework": f"13.7.2-{self._xnu_major}",
                     },
                     "/System/Library/PrivateFrameworks": {
-                        "CoreWiFi.framework":       f"13.7.2-{self._xnu_major}",
+                        "CoreWiFi.framework": f"13.7.2-{self._xnu_major}",
                     },
                 }
             },


### PR DESCRIPTION
Release 3.1.9: Legacy patch restoration and wireless refinement for Tahoe
- detect.py: Re-enable legacy hardware patches for XNU < 25 while keeping modern patches.
- modern_wireless.py: Refactor to conditionally include airportd (XNU < 25) and expand framework support to Tahoe.
- constants.py & CHANGELOG.md: Bump version to 3.1.9 and update release notes.
- legacy_wireless.py: Restore original state (already gated by detect.py).