### PR TITLE
Add support for iMac20,1 and iMac20,2 models

### DIFF
--- a/oclp_plus/datasets/model_array.py
+++ b/oclp_plus/datasets/model_array.py
@@ -100,6 +100,8 @@ SupportedSMBIOS = [
     "iMac18,3",
     "iMac19,1",
     "iMac19,2",
+    "iMac20,1",
+    "iMac20,2",
     # Mac Pro
     "MacPro3,1",
     "MacPro4,1",
@@ -210,6 +212,8 @@ ModernGPU = [
     "MacBookPro16,1",
     "MacBookPro16,2",
     "MacBookPro16,4",
+    "iMac20,1",
+    "iMac20,2",
 ]
 
 LegacyGPU = [
@@ -289,7 +293,7 @@ MacPro = ["MacPro3,1", "MacPro4,1", "MacPro5,1", "Xserve2,1", "Xserve3,1", "Dort
 # MXM iMac
 MXMiMac = ["iMac11,1", "iMac11,2", "iMac11,3", "iMac10,1", "iMac12,1", "iMac12,2", "Dortania1,1"]
 
-NoAGPMSupport = ["MacBookPro4,1", "iMac7,1", "iMac8,1", "MacPro3,1", "Xserve2,1", "MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "Dortania1,1"]
+NoAGPMSupport = ["MacBookPro4,1", "iMac7,1", "iMac8,1", "MacPro3,1", "Xserve2,1", "MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2", "Dortania1,1"]
 
 AGDPSupport = [
     "MacBookPro9,1",
@@ -307,8 +311,8 @@ AGDPSupport = [
      "iMac18,3",
      "iMac19,1",
      "iMac19,2",
-    # "iMac20,1",
-    # "iMac20,2",
+    "iMac20,1",
+    "iMac20,2",
      "iMacPro1,1",
     # "MacPro6,1",
 ]

--- a/oclp_plus/efi_builder/firmware.py
+++ b/oclp_plus/efi_builder/firmware.py
@@ -326,7 +326,7 @@ class BuildFirmware:
             # AppleMCEReporter is very picky about which models attach to the kext
             # Commonly it will kernel panic on multi-socket systems, however even on single-socket systems it may cause instability
             # To avoid any issues, we'll disable it if the spoof is set to an affected SMBIOS
-            affected_smbios = ["MacPro6,1", "MacPro7,1", "iMacPro1,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]
+            affected_smbios = ["MacPro6,1", "MacPro7,1", "iMacPro1,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]
             if self.model not in affected_smbios:
                 # If MacPro6,1 host spoofs, we can safely enable it
                 if self.constants.override_smbios in affected_smbios or generate_smbios.set_smbios_model_spoof(self.model) in affected_smbios:

--- a/oclp_plus/efi_builder/misc.py
+++ b/oclp_plus/efi_builder/misc.py
@@ -85,7 +85,7 @@ xw
         block_args = ",".join(self._re_generate_block_arguments())
         patch_args = ",".join(self._re_generate_patch_arguments())
 
-        if block_args != "" and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+        if block_args != "" and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
             logging.info(f"- Setting RestrictEvents block arguments: {block_args}")
             support.BuildSupport(self.model, self.constants, self.config).enable_kext("RestrictEvents.kext", self.constants.restrictevents_version, self.constants.restrictevents_path)
             self.config["NVRAM"]["Add"]["4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102"]["revblock"] = block_args
@@ -94,12 +94,12 @@ xw
             # Disable unneeded Userspace patching (cs_validate_page is quite expensive)
             patch_args = "none"
 
-        if patch_args != "" and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+        if patch_args != "" and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
             logging.info(f"- Setting RestrictEvents patch arguments: {patch_args}")
             support.BuildSupport(self.model, self.constants, self.config).enable_kext("RestrictEvents.kext", self.constants.restrictevents_version, self.constants.restrictevents_path)
             self.config["NVRAM"]["Add"]["4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102"]["revpatch"] = patch_args
 
-        if support.BuildSupport(self.model, self.constants, self.config).get_kext_by_bundle_path("RestrictEvents.kext")["Enabled"] is False and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+        if support.BuildSupport(self.model, self.constants, self.config).get_kext_by_bundle_path("RestrictEvents.kext")["Enabled"] is False and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
             # Ensure this is done at the end so all previous RestrictEvents patches are applied
             # RestrictEvents and EFICheckDisabler will conflict if both are injected
             support.BuildSupport(self.model, self.constants, self.config).enable_kext("EFICheckDisabler.kext", "", self.constants.efi_disabler_path)

--- a/oclp_plus/efi_builder/networking/wireless.py
+++ b/oclp_plus/efi_builder/networking/wireless.py
@@ -79,13 +79,13 @@ class BuildWirelessNetworking:
 
                 if "-amfipassbeta" not in self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"]:
                     self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " -amfipassbeta"
-                if self.model in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+                if self.model in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
                     logging.info(f"- Adding IOName spoof for {self.model} Wi-Fi")
                     if self.model == "MacPro7,1":
                         arpt_path = self.computer.wifi.pci_path or "PciRoot(0x0)/Pci(0x1C,0x5)/Pci(0x0,0x0)"
                     elif self.model in ["MacBookPro16,1", "MacBookPro16,4"]:
                         arpt_path = self.computer.wifi.pci_path or "PciRoot(0x0)/Pci(0x1D,0x0)/Pci(0x0,0x0)"
-                    elif self.model == "MacBookPro16,2":
+                    elif self.model in ["MacBookPro16,2", "iMac20,1", "iMac20,2"]:
                         arpt_path = self.computer.wifi.pci_path or "PciRoot(0x0)/Pci(0x14,0x3)"
 
                     if arpt_path not in self.config["DeviceProperties"]["Add"]:
@@ -152,13 +152,13 @@ class BuildWirelessNetworking:
         elif smbios_data.smbios_dictionary[self.model]["Wireless Model"] == device_probe.Broadcom.Chipsets.AirportBrcmNIC:
             support.BuildSupport(self.model, self.constants, self.config).enable_kext("AirportBrcmFixup.kext", self.constants.airportbcrmfixup_version, self.constants.airportbcrmfixup_path)
 
-        if self.model in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+        if self.model in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
             logging.info(f"- Adding IOName spoof for {self.model} Wi-Fi")
             if self.model == "MacPro7,1":
                 arpt_path = "PciRoot(0x0)/Pci(0x1C,0x5)/Pci(0x0,0x0)"
             elif self.model in ["MacBookPro16,1", "MacBookPro16,4"]:
                 arpt_path = "PciRoot(0x0)/Pci(0x1D,0x0)/Pci(0x0,0x0)"
-            elif self.model == "MacBookPro16,2":
+            elif self.model in ["MacBookPro16,2", "iMac20,1", "iMac20,2"]:
                 arpt_path = "PciRoot(0x0)/Pci(0x14,0x3)"
 
             if arpt_path not in self.config["DeviceProperties"]["Add"]:
@@ -187,7 +187,7 @@ class BuildWirelessNetworking:
             support.BuildSupport(self.model, self.constants, self.config).get_kext_by_bundle_path("AMFIPass.kext")["MinKernel"] = min_kernel
             if "-amfipassbeta" not in self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"]:
                 self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " -amfipassbeta"
-            if self.model in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+            if self.model in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
                 logging.info(f"- Lowering SIP for {self.model} root patching support")
                 self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["csr-active-config"] = binascii.unhexlify("03080000")
 
@@ -238,7 +238,7 @@ class BuildWirelessNetworking:
                     arpt_path = "PciRoot(0x0)/Pci(0x1C,0x5)/Pci(0x0,0x0)"
                 elif self.model in ("MacBookPro16,1", "MacBookPro16,4"):
                     arpt_path = "PciRoot(0x0)/Pci(0x1D,0x0)/Pci(0x0,0x0)"
-                elif self.model == "MacBookPro16,2":
+                elif self.model in ["MacBookPro16,2", "iMac20,1", "iMac20,2"]:
                     arpt_path = "PciRoot(0x0)/Pci(0x14,0x3)"
                 else:
                     # Assumes we have a laptop with Intel chipset

--- a/oclp_plus/efi_builder/security.py
+++ b/oclp_plus/efi_builder/security.py
@@ -47,7 +47,7 @@ class BuildSecurity:
                 self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " -amfipassbeta"
             # Adds AutoPkgInstaller for Automatic OCLP-Plus installation
             # Only install if running the GUI (AutoPkg-Assets.pkg requires the GUI)
-            if self.constants.wxpython_variant is True and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+            if self.constants.wxpython_variant is True and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
                 support.BuildSupport(self.model, self.constants, self.config).enable_kext("AutoPkgInstaller.kext", self.constants.autopkg_version, self.constants.autopkg_path)
             if self.constants.custom_sip_value:
                 logging.info(f"- Setting SIP value to: {self.constants.custom_sip_value}")
@@ -66,7 +66,7 @@ class BuildSecurity:
 
             # Patch KC UUID panics due to RSR installation
             # - Ref: https://github.com/dortania/OpenCore-Legacy-Patcher/issues/1019
-            if self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+            if self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
                 logging.info("- Enabling KC UUID mismatch patch")
                 self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " -nokcmismatchpanic"
                 support.BuildSupport(self.model, self.constants, self.config).enable_kext("RSRHelper.kext", self.constants.rsrhelper_version, self.constants.rsrhelper_path)
@@ -85,7 +85,7 @@ class BuildSecurity:
             self.config["NVRAM"]["Add"]["4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102"]["OCLP-Settings"] += " -allow_amfi"
             # CSLVFixup simply patches out __RESTRICT and __restrict out of the Music.app Binary
             # Ref: https://pewpewthespells.com/blog/blocking_code_injection_on_ios_and_os_x.html
-            if self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+            if self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
                 support.BuildSupport(self.model, self.constants, self.config).enable_kext("CSLVFixup.kext", self.constants.cslvfixup_version, self.constants.cslvfixup_path)
 
         if self.constants.secure_status is False:

--- a/oclp_plus/efi_builder/smbios.py
+++ b/oclp_plus/efi_builder/smbios.py
@@ -63,7 +63,7 @@ class BuildSMBIOS:
             support.BuildSupport(self.model, self.constants, self.config).get_item_by_kv(self.config["ACPI"]["Patch"], "Comment", "EHC1 to EH01")["Enabled"] = True
             support.BuildSupport(self.model, self.constants, self.config).get_item_by_kv(self.config["ACPI"]["Patch"], "Comment", "EHC2 to EH02")["Enabled"] = True
 
-        if self.model == self.constants.override_smbios and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4"]:
+        if self.model == self.constants.override_smbios and self.model not in ["MacPro7,1", "MacBookPro16,1", "MacBookPro16,2", "MacBookPro16,4", "iMac20,1", "iMac20,2"]:
             if "-no_compat_check" not in self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"]:
                 logging.info("- Adding -no_compat_check")
                 self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " -no_compat_check"

--- a/oclp_plus/support/generate_smbios.py
+++ b/oclp_plus/support/generate_smbios.py
@@ -46,6 +46,9 @@ def set_smbios_model_spoof(model):
         elif model.startswith("Macmini"):
             return "Macmini8,1"
         elif model.startswith("iMac"):
+            if smbios_data.smbios_dictionary[model]["Max OS Supported"] == os_data.os_data.max_os:
+                # Models supported in Tahoe
+                return model
             if smbios_data.smbios_dictionary[model]["Max OS Supported"] <= os_data.os_data.high_sierra:
                 # Models dropped in Mojave either do not have an iGPU, or should have them disabled
                 return "iMacPro1,1"


### PR DESCRIPTION
- Include iMac20,1 and iMac20,2 in SupportedSMBIOS, ModernGPU, NoAGPMSupport, and AGDPSupport.
- Update EFI builder to treat these models as native Tahoe models, excluding redundant patches and kexts.
- Add Wi-Fi spoofing and PCI pathing for iMac20,x on macOS Tahoe.
- Update SMBIOS generation to avoid unnecessary spoofing for these models on Tahoe.