### PR TITLE
Universal OCLP Manifest Detection & Validation Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Starting with macOS Tahoe Beta 2, Apple removed the legacy `AppleHDA.kext`. This
 
 ### 💾 Installation Requirements
 💡  **Before Running Post-Install Patches:**
+
+⚠️ **Root Volume Dirty Error:**
+If the patcher detects that the system volume has been modified (e.g., patches already applied or seal broken), it will block further patching to prevent system instability.
+* **To re-patch:** You must first use the "Revert Root Patches" button to restore the original system state.
+* **If no manifest is found:** If the volume is modified but the patcher cannot find a record of what was installed, it will display a "Root volume is modified" error. In this case, you should still attempt a "Revert Root Patches" or reinstall macOS to clean the volume.
+
 * **KDK is mandatory:** For macOS 13 through Tahoe (26.x), the Kernel Debug Kit must be installed for drivers like AppleHDA to link correctly. Use the Help > Download KDK button.
 
 ⚠️ **Resource Dependency Notice**

--- a/oclp_plus/support/utilities.py
+++ b/oclp_plus/support/utilities.py
@@ -133,6 +133,44 @@ def check_seal():
     else:
         return False
 
+
+def find_any_oclp_manifest(root_path: Path = Path("/")):
+    """
+    Finds any OCLP-based manifest file in /System/Library/CoreServices/
+    """
+    core_services_path = root_path / "System/Library/CoreServices/"
+    if not core_services_path.exists():
+        return None
+
+    # Known Apple system plists to ignore
+    apple_plists = [
+        "SystemVersion.plist",
+        "PlatformSupport.plist",
+        "BuildInfo.plist",
+        "ServerVersion.plist",
+        "License.plist",
+        "ProductInfo.plist",
+        "DefaultDesktop.plist",
+        "BridgeVersion.plist",
+        "BaseSystemResources.plist",
+        "Siri.plist",
+        "com.apple.recoveryview.plist",
+    ]
+
+    for plist_path in core_services_path.glob("*.plist"):
+        if plist_path.name in apple_plists:
+            continue
+
+        try:
+            with open(plist_path, "rb") as f:
+                data = plistlib.load(f)
+                if any(key in data for key in ["OCLP-Plus", "OpenCore-Patcher", "PatcherSupportPkg", "Time Patched"]):
+                    return plist_path
+        except Exception:
+            continue
+
+    return None
+
 def check_filesystem_type():
     # Expected to return 'apfs'
     filesystem_type = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", "/"], stdout=subprocess.PIPE).stdout.decode().strip().encode())

--- a/oclp_plus/sys_patch/patchsets/detect.py
+++ b/oclp_plus/sys_patch/patchsets/detect.py
@@ -87,6 +87,8 @@ class HardwarePatchsetValidation(StrEnum):
     FORCE_OPENGL_MISSING          = "Validation: Force OpenGL property missing"
     FORCE_COMPAT_MISSING          = "Validation: Force compat property missing"
     NVDA_DRV_MISSING              = "Validation: nvda_drv(_vrl) variable missing"
+    REPATCHING_NOT_SUPPORTED      = "Validation: Please revert root patches before re-patching"
+    ROOT_VOLUME_DIRTY             = "Validation: Root volume is modified"
     PATCHING_NOT_POSSIBLE         = "Validation: Patching not possible"
     UNPATCHING_NOT_POSSIBLE       = "Validation: Unpatching not possible"
 
@@ -266,6 +268,26 @@ class HardwarePatchsetDetection:
         if nv_on:
             return False
         return True
+
+
+    def _is_root_volume_dirty(self, manifest_path: Path = None) -> bool:
+        """
+        Determine if root volume is dirty
+        """
+        if utilities.check_seal() is False:
+            return True
+        if manifest_path is not None:
+            return True
+        return False
+
+
+    def _validation_check_repatching_is_possible(self, manifest_path: Path = None) -> bool:
+        """
+        Determine if re-patching is possible
+        """
+        if self._is_root_volume_dirty(manifest_path) is True:
+            return True
+        return False
 
 
     @cache
@@ -498,6 +520,8 @@ class HardwarePatchsetDetection:
 
         requires_network_connection = missing_metallib_support_pkg or missing_kernel_debug_kit
 
+        manifest_path = utilities.find_any_oclp_manifest(root_path=Path(self._constants.mount_root) if hasattr(self._constants, "mount_root") else Path("/"))
+
         requirements = {
             HardwarePatchsetSettings.KERNEL_DEBUG_KIT_REQUIRED:     requires_kernel_debug_kit,
             HardwarePatchsetSettings.KERNEL_DEBUG_KIT_MISSING:      missing_kernel_debug_kit,
@@ -514,7 +538,15 @@ class HardwarePatchsetDetection:
             HardwarePatchsetValidation.FORCE_OPENGL_MISSING:        self._validation_check_force_opengl_missing()  if has_nvidia_web_drivers is True else False,
             HardwarePatchsetValidation.FORCE_COMPAT_MISSING:        self._validation_check_force_compat_missing()  if has_nvidia_web_drivers is True else False,
             HardwarePatchsetValidation.NVDA_DRV_MISSING:            self._validation_check_nvda_drv_missing()      if has_nvidia_web_drivers is True else False,
+            HardwarePatchsetValidation.REPATCHING_NOT_SUPPORTED:    False,
+            HardwarePatchsetValidation.ROOT_VOLUME_DIRTY:           False,
         }
+
+        if self._validation_check_repatching_is_possible(manifest_path) is True:
+            if manifest_path is not None:
+                requirements[HardwarePatchsetValidation.REPATCHING_NOT_SUPPORTED] = True
+            else:
+                requirements[HardwarePatchsetValidation.ROOT_VOLUME_DIRTY] = True
 
         _cant_patch   = False
         _cant_unpatch = requirements[HardwarePatchsetValidation.SIP_ENABLED]

--- a/oclp_plus/wx_gui/gui_sys_patch_display.py
+++ b/oclp_plus/wx_gui/gui_sys_patch_display.py
@@ -150,7 +150,7 @@ class SysPatchDisplayFrame(wx.Frame):
                     patch_label.SetLabel(patch_label.GetLabel().replace("-", ""))
                     patch_label.Centre(wx.HORIZONTAL)
 
-            if patches[HardwarePatchsetValidation.PATCHING_NOT_POSSIBLE] is True:
+            if patches[HardwarePatchsetValidation.PATCHING_NOT_POSSIBLE] is True or no_new_patches is True:
                 # Cannot patch due to the following reasons:
                 patch_label = wx.StaticText(frame, label="Cannot patch due to the following reasons:", pos=(-1, patch_label.GetPosition()[1] + 25))
                 patch_label.SetFont(gui_support.font_factory(13, wx.FONTWEIGHT_BOLD))


### PR DESCRIPTION
I have implemented a universal manifest detection system that identifies OCLP root patches regardless of the filename used by different forks. 

Specifically, I:
1.  **Enhanced Manifest Detection**: Created `find_any_oclp_manifest` in `utilities.py`. It scans `/System/Library/CoreServices/` for any `.plist` files, ignoring known Apple system files, and looks for signature OCLP keys.
2.  **Restored and Refined Validation**: In `detect.py`, I re-introduced the logic to prevent re-patching over an existing installation. I split the error into two specific cases:
    - `REPATCHING_NOT_SUPPORTED`: Shown when a manifest is found, advising the user to "Revert Root Patches" first.
    - `ROOT_VOLUME_DIRTY`: Shown when the volume seal is broken but no manifest is found (e.g., failed or unknown patches), advising general cleanup.
3.  **GUI Improvements**: Updated `gui_sys_patch_display.py` to ensure that if a user is blocked from patching due to an existing installation, they are clearly shown the reason why, even if the current patcher thinks no *new* patches are needed.
4.  **Documentation**: Updated `README.md` to explain these new validation states to the user.

This approach is more robust and user-friendly than the previous name-based check.

---
*PR created automatically by Jules for task [15101049323706984645](https://jules.google.com/task/15101049323706984645) started by @YBronst*